### PR TITLE
Feature: Name pages with up to 4 leading zeroes

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -323,11 +323,11 @@ func download(chapter float32) bool {
 
 	doc.Find("img").Each(func(i int, selection *goquery.Selection) {
 		imageURL, _ := selection.Attr("data-src")
-		fileName := fmt.Sprintf("%s/page%v.jpg", dir, i)
+		fileName := fmt.Sprintf("%s/page%04d.jpg", dir, i)
 
 		err = dl.DownloadFile(imageURL, fileName)
 		if err == nil && output != "pdf" {
-			fmt.Println("Downloading ::", fmt.Sprintf("%s/page%v.jpg", dir, i))
+			fmt.Println("Downloading ::", fileName)
 		}
 	})
 	return true


### PR DESCRIPTION
This allows for the manga to be sorted properly in its download folder (as long as each chapter
is below 9999 pages)

Related to #10 