### PR TITLE
Update install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -3,12 +3,14 @@
 ## UNCOMMENT THESE LINES IF YOU WANT TO BUILD FROM SOURCE
 #echo Removing pre-built binary
 #rm mangodl
+#rm /usr/local/bin/mangodl
 #echo Installing the needed dependencies
 #go get -d ./...
 #echo Building...
-#go build
+#go build main.go
+#mv main mangodl
 
 # make the file executable
 chmod +x mangodl
 # install the executable to /usr/bin
-sudo install -m755 mangodl /usr/bin/mangodl
+sudo install -m755 mangodl /usr/local/bin/mangodl


### PR DESCRIPTION
https://unix.stackexchange.com/questions/8656/usr-bin-vs-usr-local-bin-on-linux

When I tried using install.sh on MacOS 12.3.1 it kept denying me access:
- to `/usr/bin/` directly
  - I would have to disable MacOS's SIP for that to work

Instead: used a workaround
- to install to `/usr/local/bin/` 
   - which also works fine on linux

![install-where](https://user-images.githubusercontent.com/88108711/168224887-008dd4c3-748b-499f-b25d-084bcd0a0c75.png)
